### PR TITLE
Set GOTEST_RACE=0 for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
   - wget https://github.com/mewmew/ci/raw/master/get_tools.sh
   - chmod +x get_tools.sh
   - ./get_tools.sh
-  - wget https://github.com/mewmew/ci/raw/master/ci_checks.sh
+  - wget https://github.com/pwaller/ci/raw/pwaller-patch-1/ci_checks.sh
   - chmod +x ci_checks.sh
 
 script:
-  - ./ci_checks.sh
+  - GOTEST_RACE=0 ./ci_checks.sh


### PR DESCRIPTION
Fix #19.

Note: The change to use pwaller/ci is just to allow me to hack on the CI script. The CI change will need upstreaming if it is correct as well. If it's not correct, I may abandon this, but I thought this might be a quick fix.